### PR TITLE
Automatically check/uncheck child nodes when parent is checked

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
@@ -102,7 +102,15 @@ namespace TestCentric.Gui.Views
 
             treeView.AfterSelect += (s, e) => SelectedNodeChanged?.Invoke(e.Node);
 
-            treeView.AfterCheck += (s, e) => AfterCheck?.Invoke(e.Node);
+            treeView.AfterCheck += (s, e) =>
+            {
+                // Update checked state of all child nodes if action is triggered by user
+                // But not if triggered programmatically. For example while restoring VisualState or while setting child nodes
+                if (e.Action == TreeViewAction.ByMouse || e.Action == TreeViewAction.ByKeyboard)
+                    SetCheckedStateOfChildNodes(e.Node, e.Node.Checked);
+
+                AfterCheck?.Invoke(e.Node);
+            };
         }
 
         #region Properties
@@ -270,6 +278,15 @@ namespace TestCentric.Gui.Views
         #endregion
 
         #region Helper Methods
+
+        private void SetCheckedStateOfChildNodes(TreeNode node, bool isChecked)
+        {
+            foreach (TreeNode childNode in node.Nodes)
+            {
+                childNode.Checked = node.Checked;
+                SetCheckedStateOfChildNodes(childNode, isChecked);
+            }
+        }
 
         private IList<TreeNode> GetCheckedNodes()
         {

--- a/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
@@ -3,10 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using System.Drawing;
 using System.Windows.Forms;
-using System.IO;
-using System.Reflection;
 
 namespace TestCentric.Gui.Views
 {
@@ -46,6 +43,7 @@ namespace TestCentric.Gui.Views
         public event TreeNodeActionHandler TreeNodeDoubleClick;
         public event EventHandler ContextMenuOpening;
 
+        private bool _suppressAfterCheckEvent = false;
         public TestTreeView()
         {
             InitializeComponent();
@@ -104,10 +102,17 @@ namespace TestCentric.Gui.Views
 
             treeView.AfterCheck += (s, e) =>
             {
+                if (_suppressAfterCheckEvent)
+                    return;
+
                 // Update checked state of all child nodes if action is triggered by user
                 // But not if triggered programmatically. For example while restoring VisualState or while setting child nodes
                 if (e.Action == TreeViewAction.ByMouse || e.Action == TreeViewAction.ByKeyboard)
+                {
+                    _suppressAfterCheckEvent = true;
                     SetCheckedStateOfChildNodes(e.Node, e.Node.Checked);
+                    _suppressAfterCheckEvent = false;
+                }
 
                 AfterCheck?.Invoke(e.Node);
             };


### PR DESCRIPTION
This PR fixes #199 by automatically check/uncheck all child nodes when parent node is checked/unchecked.

Actually, only all child nodes need to be updated as soon as the check state of one node changes. However in addition we need to distingush if the action is triggered by the user or programmatically. An example for programmatically is while restoring the check state from the VisualState file or another example while we updating the child node state the TreeView invoke the event again.

Fortunately, the TreeView event provides an EventArgument that can be used to detect this.