### PR TITLE
Update agent versions

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -74,9 +74,9 @@ var NuGetGuiPackage = new NuGetPackage(
 				"Images/Tree/Visual Studio/Success_NotLatestRun.png", "Images/Tree/Visual Studio/Failure_NotLatestRun.png", "Images/Tree/Visual Studio/Warning_NotLatestRun.png", "Images/Tree/Visual Studio/Ignored_NotLatestRun.png", "Images/Tree/Visual Studio/Inconclusive_NotLatestRun.png", 
 				"Images/Tree/Visual Studio/Running.png",  "Images/Tree/Visual Studio/Skipped.png") )
 		.WithDependencies(
-			KnownExtensions.Net462PluggableAgent.SetVersion("2.6.0-dev00011").NuGetPackage,
-			KnownExtensions.Net60PluggableAgent.SetVersion("2.5.3-dev00004").NuGetPackage,
-			KnownExtensions.Net80PluggableAgent.SetVersion("2.5.4-dev00002").NuGetPackage
+			KnownExtensions.Net462PluggableAgent.SetVersion("2.6.0-dev00013").NuGetPackage,
+			KnownExtensions.Net60PluggableAgent.SetVersion("2.5.3-dev00005").NuGetPackage,
+			KnownExtensions.Net80PluggableAgent.SetVersion("2.5.4-dev00003").NuGetPackage
         ),
 	testRunner: new GuiSelfTester(BuildSettings.NuGetTestDirectory + "TestCentric.GuiRunner." + BuildSettings.PackageVersion + "/tools/testcentric.exe"),
 	checks: new PackageCheck[] {
@@ -115,9 +115,9 @@ var ChocolateyGuiPackage = new ChocolateyPackage(
 				"Images/Tree/Visual Studio/Success_NotLatestRun.png", "Images/Tree/Visual Studio/Failure_NotLatestRun.png", "Images/Tree/Visual Studio/Warning_NotLatestRun.png", "Images/Tree/Visual Studio/Ignored_NotLatestRun.png", "Images/Tree/Visual Studio/Inconclusive_NotLatestRun.png", 
 				"Images/Tree/Visual Studio/Running.png", "Images/Tree/Visual Studio/Skipped.png"))
         .WithDependencies(
-			KnownExtensions.Net462PluggableAgent.SetVersion("2.6.0-dev00011").ChocoPackage,
-			KnownExtensions.Net60PluggableAgent.SetVersion("2.5.3-dev00004").ChocoPackage,
-			KnownExtensions.Net80PluggableAgent.SetVersion("2.5.4-dev00002").ChocoPackage
+			KnownExtensions.Net462PluggableAgent.SetVersion("2.6.0-dev00013").ChocoPackage,
+			KnownExtensions.Net60PluggableAgent.SetVersion("2.5.3-dev00005").ChocoPackage,
+			KnownExtensions.Net80PluggableAgent.SetVersion("2.5.4-dev00003").ChocoPackage
         ),
 	testRunner: new GuiSelfTester(BuildSettings.ChocolateyTestDirectory + "testcentric-gui." + BuildSettings.PackageVersion + "/tools/testcentric.exe"),
 	checks: new PackageCheck[] {


### PR DESCRIPTION
This is aimed at fixing the problem of stack overflow when `RemoteTestAgent.Stop()` is  called.