### PR TITLE
Reload tests: keep and dim test results from previous run

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -120,10 +120,7 @@ namespace TestCentric.Gui.Presenters
             {
                 VisualState visualState = applyVisualState ? CreateVisualState() : null;
                 OnTestLoaded(testNode, visualState);
-
-                if (_view.Nodes != null) // TODO: Null when mocked
-                    foreach (TreeNode treeNode in _view.Nodes)
-                        ApplyResultsToTree(treeNode);
+                ApplyResultsToTree();
             }
         }
 
@@ -275,6 +272,15 @@ namespace TestCentric.Gui.Presenters
                         ? latestRun ? TestTreeView.IgnoredIndex : TestTreeView.IgnoredIndex_NotLatestRun
                         : TestTreeView.SkippedIndex;
             }
+        }
+
+        protected void ApplyResultsToTree()
+        {
+            if (!_model.HasResults || _view.Nodes == null)
+                return;
+
+            foreach (TreeNode treeNode in _view.Nodes)
+                ApplyResultsToTree(treeNode);
         }
 
         private void ApplyResultsToTree(TreeNode treeNode)

--- a/src/GuiRunner/TestCentric.Gui/Presenters/FixtureListDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/FixtureListDisplayStrategy.cs
@@ -81,6 +81,7 @@ namespace TestCentric.Gui.Presenters
             }
 
             visualState?.ApplyTo(_view.TreeView);
+            ApplyResultsToTree();
         }
 
         #endregion

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -65,6 +65,7 @@ namespace TestCentric.Gui.Presenters
             else
                 SetDefaultInitialExpansion();
 
+            ApplyResultsToTree();
             _view.EnableTestFilter(true);
         }
 

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
@@ -93,6 +93,7 @@ namespace TestCentric.Gui.Presenters
             }
 
             visualState?.ApplyTo(_view.TreeView);
+            ApplyResultsToTree();
         }
 
         protected override VisualState CreateVisualState() => new VisualState("TEST_LIST", _grouping?.ID).LoadFrom(_view.TreeView);

--- a/src/GuiRunner/TestModel.Tests/ResultNodeTests.cs
+++ b/src/GuiRunner/TestModel.Tests/ResultNodeTests.cs
@@ -22,6 +22,22 @@ namespace TestCentric.Gui.Model
         }
 
         [Test]
+        public void CreateResultNode_FromOldResult()
+        {
+            // Act
+            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' result='Passed'/>");
+
+            // Arrange
+            ResultNode newResultNode = ResultNode.Create(resultNode.Xml, "100");
+
+            // Assert
+            Assert.That(newResultNode.Id, Is.EqualTo("100"));
+            Assert.That(newResultNode.FullName, Is.EqualTo(resultNode.FullName));
+            Assert.That(newResultNode.Status, Is.EqualTo(resultNode.Status));
+            Assert.That(newResultNode.IsLatestRun, Is.EqualTo(false));
+        }
+
+        [Test]
         public void IsLatestRun_NewResultNode_IsTrue()
         {
             var resultNode = new ResultNode("<test-case id='1'/>");

--- a/src/GuiRunner/TestModel/ResultNode.cs
+++ b/src/GuiRunner/TestModel/ResultNode.cs
@@ -33,6 +33,16 @@ namespace TestCentric.Gui.Model
 
         public ResultNode(string xmlText) : this(XmlHelper.CreateXmlNode(xmlText)) { }
 
+        /// <summary>
+        /// Creates a ResultNode from an existing XmlNode, but replacing the ID
+        /// </summary>
+        public static ResultNode Create(XmlNode xmlNode, string newId)
+        {
+            var attribute = xmlNode.Attributes["id"];
+            attribute.Value = newId;
+            return new ResultNode(xmlNode) { IsLatestRun = false };
+        }
+
         #endregion
 
         #region Public Properties

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -507,7 +507,7 @@ namespace TestCentric.Gui.Model
             BuildTestIndex();
             TestCentricTestFilter.Init();
 
-            ClearResults();
+            RestoreTestResults();
 #endif
 
             _events.FireTestReloaded(LoadedTests);
@@ -673,6 +673,40 @@ namespace TestCentric.Gui.Model
         {
             Results.Clear();
             ResultSummary = null;
+        }
+
+        private void RestoreTestResults()
+        {
+            // Get all existing test results
+            List<ResultNode> oldResults = Results.Values.ToList();
+            Results.Clear();
+
+            // Search for TestFullName in all nodes
+            foreach (ResultNode oldResult in oldResults)
+            {
+                TestNode testNode = TryGetTestNode(LoadedTests, oldResult.FullName);
+                if (testNode != null)
+                {
+                    // Create new result: keep result content, but use current test ID
+                    ResultNode newResult = ResultNode.Create(oldResult.Xml, testNode.Id);
+                    Results.Add(testNode.Id, newResult);
+                }
+            }
+        }
+
+        private TestNode TryGetTestNode(TestNode testNode, string fullName)
+        {
+            if (testNode.FullName == fullName)
+                return testNode;
+
+            foreach (var childNode in testNode.Children)
+            {
+                var foundNode = TryGetTestNode(childNode, fullName);
+                if (foundNode != null)
+                    return foundNode;
+            }
+
+            return null;
         }
 
         public void SelectCategories(IList<string> categories, bool exclude)


### PR DESCRIPTION
This PR fixes #231.

Dimming of test results from previous runs were already introduced with #1243. So the general approach to dim test results were already available. The challenge for applying this approach when reloading was mainly to identify the matching test node for a given test result. The test ID cannot be used here, because it might change during reload. Therefore the test fullname was used instead. This means if neither the namespace, class name or test method name was changed, a test result can be applied. Obviously there's no matching result node for newly added tests. And of course test results of deleted tests are removed as well.

There are some edge cases in which we fail to identify the matching test: for example renaming a namespace or deleting+recreating a test with the identical name. But I believe using the FullName is also understandable for the user.    