### PR TITLE
Fix category grouping when category is defined several times

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitGrouping/CategoryGroupingTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitGrouping/CategoryGroupingTests.cs
@@ -334,6 +334,30 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
             AssertTestCase(_createNodes[1].Nodes[0].Nodes[1].Nodes[0].Nodes[0], "TestB");
         }
 
+        [Test]
+        public void CreateTree_SameCategory_DefinedMultipleTimes_AllTreeNodes_AreCreated()
+        {
+            // Arrange
+            TestNode testNode = new TestNode(
+                CreateTestSuiteXml("3-1000", "LibraryA",
+                    CreateTestSuiteXml("3-1001", "NamespaceA",
+                        CreateTestFixtureXml("3-1010", "Fixture_1", new List<string>() { "CategoryA", "CategoryA" },
+                            CreateTestcaseXml("3-1011", "TestA", "CategoryA"),
+                            CreateTestcaseXml("3-1012", "TestB", "")))));
+
+            // Act
+            var grouping = new CategoryGrouping(_strategy, _model, _view);
+            grouping.CreateTree(testNode);
+
+            // Assert tree nodes
+            Assert.That(_createNodes.Count, Is.EqualTo(1));
+            AssertTreeNodeGroup(_createNodes[0], "CategoryA", 2, 1);
+            AssertTreeNodeGroup(_createNodes[0].Nodes[0], "LibraryA.NamespaceA", 2, 1);
+            AssertTreeNodeGroup(_createNodes[0].Nodes[0].Nodes[0], "Fixture_1", 2, 2);
+            AssertTestCase(_createNodes[0].Nodes[0].Nodes[0].Nodes[0], "TestA");
+            AssertTestCase(_createNodes[0].Nodes[0].Nodes[0].Nodes[1], "TestB");
+        }
+
         private void AssertTestCase(TreeNode treeNode, string expectedName)
         {
             Assert.That(treeNode.Nodes.Count, Is.EqualTo(0));

--- a/src/GuiRunner/TestCentric.Gui/DialogManager.cs
+++ b/src/GuiRunner/TestCentric.Gui/DialogManager.cs
@@ -18,7 +18,6 @@ namespace TestCentric.Gui.Views
             OpenFileDialog dlg = CreateOpenFileDialog(title, filter);
 
             dlg.Multiselect = true;
-
             return dlg.ShowDialog() == DialogResult.OK
                 ? dlg.FileNames
                 : new string[0];

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGrouping.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGrouping.cs
@@ -33,7 +33,7 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
             foreach (XmlNode node in testNode.Xml.SelectNodes(xpathExpression))
             {
                 var groupName = node.Attributes["value"].Value;
-                if (!string.IsNullOrEmpty(groupName))
+                if (!string.IsNullOrEmpty(groupName) && !categories.Contains(groupName))
                     categories.Add(groupName);
             }
 


### PR DESCRIPTION
Fixes #1296.

When retrieving the list of available categories, we avoid to add duplicate entries now.