### PR TITLE
Fix DisplayFixture when tree grouping is active

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -287,10 +287,10 @@ namespace TestCentric.Gui.Presenters.TestTree
             // Arrange
             _settings.Gui.TestTree.ShowNamespace = false;
             string xml =
-                "<test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
+                "<test-run> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
                     "<test-suite type='TestSuite' id='1-1031' name='Library'>" +
                     "</test-suite>" +
-                "</test-suite>";
+                "</test-suite> </test-run>";
 
             // Act
             _strategy.OnTestLoaded(new TestNode(xml), null);
@@ -436,6 +436,44 @@ namespace TestCentric.Gui.Presenters.TestTree
 
             // Assert
             _view.Received().EnableTestFilter(false);
+        }
+
+        [Test]
+        public void CollapseToFixtures_AllFixtureNodes_AreShown()
+        {
+            // Arrange
+            var treeView = new TreeView();
+            _view.TreeView.Returns(treeView);
+
+            var rootNode = _view.Nodes[0];
+            var fixtureNode1 = CreateTreeNode("<test-suite type='TestFixture' id='2' name='FixtureA'/>");
+            var fixtureNode2 = CreateTreeNode("<test-suite type='TestFixture' id='3' name='FixtureB'/>");
+            rootNode.Nodes.AddRange(new []{ fixtureNode1, fixtureNode2 });
+
+            var testcase1 = CreateTreeNode("<test-case id='10' name='Test1'/>");
+            var testcase2 = CreateTreeNode("<test-case id='20' name='Test2'/>");
+            fixtureNode1.Nodes.AddRange(new[] { testcase1, testcase2 });
+
+            var testcase3 = CreateTreeNode("<test-case id='30' name='Test3'/>");
+            var testcase4 = CreateTreeNode("<test-case id='40' name='Test4'/>");
+            fixtureNode2.Nodes.AddRange(new[] { testcase3, testcase4 });
+
+            rootNode.ExpandAll();
+
+            // Act
+            _strategy.CollapseToFixtures();
+
+            // Assert
+            Assert.That(rootNode.IsExpanded, Is.EqualTo(true));
+            Assert.That(fixtureNode1.IsExpanded, Is.EqualTo(false));
+            Assert.That(fixtureNode2.IsExpanded, Is.EqualTo(false));
+        }
+
+        TreeNode CreateTreeNode(string testNodeXml)
+        {
+            var testNode = new TestNode(testNodeXml);
+            return new TreeNode() { Tag = testNode };
+
         }
     }
 

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -12,6 +12,7 @@ namespace TestCentric.Gui.Presenters
     using Model.Settings;
     using Views;
     using System.Linq;
+    using TestCentric.Gui.Presenters.NUnitGrouping;
 
     /// <summary>
     /// DisplayStrategy is the abstract base for the various
@@ -352,14 +353,21 @@ namespace TestCentric.Gui.Presenters
 
         public void CollapseToFixtures()
         {
+            _view.TreeView.BeginUpdate();
+
             if (_view.Nodes != null) // TODO: Null when mocked
                 foreach (TreeNode treeNode in _view.Nodes)
                     CollapseToFixtures(treeNode);
+
+            _view.TreeView.EndUpdate();
         }
 
         protected void CollapseToFixtures(TreeNode treeNode)
         {
-            var testNode = treeNode.Tag as TestNode;
+            TestNode testNode = treeNode.Tag as TestNode;
+            if (testNode == null && treeNode.Tag is GroupingTestGroup group)
+                testNode = group.AssociatedTestNode;
+
             if (testNode != null && testNode.Type == "TestFixture")
                 treeNode.Collapse();
             else if (testNode == null || testNode.IsSuite)

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGrouping.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGrouping.cs
@@ -42,5 +42,11 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
 
             return categories;
         }
+
+        /// <inheritdoc />
+        protected override TestGroup CreateTestGroup(string name, TestNode testNode)
+        {
+            return new CategoryGroupingTestGroup(testNode, CurrentRootGroupName, name);
+        }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGroupingTestGroup.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGroupingTestGroup.cs
@@ -1,0 +1,24 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters.NUnitGrouping
+{
+    using TestCentric.Gui.Model;
+
+    /// <summary>
+    /// A specialist TestGroup class which provides the Category for the TestFilter
+    /// </summary>
+    public class CategoryGroupingTestGroup : GroupingTestGroup
+    {
+        /// <inheritdoc />
+        public CategoryGroupingTestGroup(TestNode associatedTestNode, string category, string name)
+            : base(associatedTestNode, name)
+        {
+            Category = category;
+        }
+
+        public string Category { get; set; }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/GroupingBase.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/GroupingBase.cs
@@ -44,6 +44,8 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
 
         protected INUnitTreeDisplayStrategy Strategy { get; }
 
+        protected string CurrentRootGroupName { get; set; }
+
         /// <summary>
         /// Derived classes might set this value, if test cases might need to be regrouped after a test run
         /// For example duration or outcome grouping
@@ -149,12 +151,13 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
         /// </summary>
         private TreeNode GetOrCreateRootTreeNode(string groupName)
         {
+            CurrentRootGroupName = groupName;
             foreach (TestGroup rootGroup in _rootGroups)
                 if (rootGroup.Name == groupName)
                     return rootGroup.TreeNode;
 
             // TreeNode doesn't exist => create it
-            var group = new TestGroup(groupName);
+            TestGroup group = CreateTestGroup(groupName, Model.LoadedTests);
 
             _rootGroups.Add(group);
             _groups.Add(group);
@@ -226,7 +229,7 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
 
         private TreeNode CreateTreeNode(TreeNode parentTreeNode, TestNode testNode, string name)
         {
-            TreeNode treeNode = !testNode.IsSuite ? Strategy.MakeTreeNode(testNode) : Strategy.MakeTreeNode(new TestGroup(name));
+            TreeNode treeNode = !testNode.IsSuite ? Strategy.MakeTreeNode(testNode) : Strategy.MakeTreeNode(CreateTestGroup(name, testNode));
             parentTreeNode?.Nodes.Add(treeNode);
 
             if (treeNode.Tag is TestGroup g)
@@ -236,6 +239,11 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
             }
 
             return treeNode;
+        }
+
+        protected virtual TestGroup CreateTestGroup(string name, TestNode testNode)
+        {
+            return new GroupingTestGroup(testNode, name);
         }
 
         private void AddTestToGroups(IList<TreeNode> treeNodes, TestNode testNode)

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/GroupingTestGroup.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/GroupingTestGroup.cs
@@ -1,0 +1,29 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters.NUnitGrouping
+{
+    using TestCentric.Gui.Model;
+
+    /// <summary>
+    /// A specialist TestGroup class which provides the associated TestNode within the NUnit tree
+    /// </summary>
+    public class GroupingTestGroup : TestGroup
+    {
+        /// <inheritdoc />
+        public GroupingTestGroup(TestNode associatedTestNode, string name) : base(name)
+        {
+            AssociatedTestNode = associatedTestNode;
+        }
+
+        /// <inheritdoc />
+        public GroupingTestGroup(TestNode associatedTestNode, string name, int imageIndex) : base(name, imageIndex)
+        {
+            AssociatedTestNode = associatedTestNode;
+        }
+
+        public TestNode AssociatedTestNode { get; set; }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -27,6 +27,7 @@ namespace TestCentric.Gui.Presenters
             : base(view, model) 
         {
             _view.SetTestFilterVisibility(model.Settings.Gui.TestTree.ShowFilter);
+            _view.CollapseToFixturesCommand.Enabled = true;
         }
 
 


### PR DESCRIPTION
Fixes #1304 

The TestGroups used in case of tree grouping contain all the test cases of that group, but has no information about the associated TestNode in the NUnit tree. Therefore it's not aware if it's representing a fixture node or not and cannot expand/collapse accordingly. The missing information is added now, so that it can decide properly.
