### PR TITLE
ExpandAll nodes: improve performance

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -60,12 +60,15 @@ namespace TestCentric.Gui.Presenters
                         _view.Add(CreateNUnitTreeNode(null, topLevelNode));
             }
 
+            _view.TreeView?.BeginUpdate();
             if (visualState != null)
                 visualState.ApplyTo(_view.TreeView);
             else
                 SetDefaultInitialExpansion();
 
             ApplyResultsToTree();
+            _view.TreeView?.EndUpdate();
+
             _view.EnableTestFilter(true);
         }
 

--- a/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
@@ -216,7 +216,13 @@ namespace TestCentric.Gui.Views
             treeView.EndUpdate();
             treeView.Select();
         });
-        public void ExpandAll() => InvokeIfRequired(() => treeView.ExpandAll());
+
+        public void ExpandAll() => InvokeIfRequired(() =>
+        {
+             treeView.BeginUpdate();
+             treeView.ExpandAll();
+             treeView.EndUpdate();
+        }); 
         public void CollapseAll() => InvokeIfRequired(() => treeView.CollapseAll());
         public void SetImageIndex(TreeNode treeNode, int imageIndex) =>
             InvokeIfRequired(() => treeNode.ImageIndex = treeNode.SelectedImageIndex = imageIndex);


### PR DESCRIPTION
Fixes #1306 by adding BeginUpdate() + EndUpdate() statements around ExpandAll() call.

See also screenshots in issue.