### PR TITLE
Use enhanced NUnit filter for test runs when category filtering/grouping or test name filtering is active

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/CategoryGroupingTestGroupTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/CategoryGroupingTestGroupTests.cs
@@ -1,0 +1,206 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using TestCentric.Gui.Presenters.NUnitGrouping;
+
+namespace TestCentric.Gui.Presenters.Filter
+{
+    using NSubstitute;
+    using NUnit.Framework;
+    using TestCentric.Gui.Model;
+    using TestCentric.Gui.Model.Filter;
+
+    [TestFixture]
+    internal class CategoryGroupingTestGroupTests
+    {
+        private ITestCentricTestFilter _guiFilter;
+        private TestNode _loadedTests;
+
+        [SetUp]
+        public void Setup()
+        {
+            _guiFilter = Substitute.For<ITestCentricTestFilter>();
+            _loadedTests = TestFilterData.GetSampleTestProject();
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestRun_ReturnsCategoryFilterWithoutExplicit()
+        {
+            // Arrange
+            var group = new CategoryGroupingTestGroup(_loadedTests, "CategoryA", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+                TestFilterData.GetTestById(_loadedTests, "3-2011"),
+                TestFilterData.GetTestById(_loadedTests, "3-2012"),
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><not><or><id>3-3010</id><id>3-4012</id></or></not><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestAssembly_ReturnsCategoryFilter()
+        {
+            // Arrange
+            TestNode associatedNode = TestFilterData.GetTestById(_loadedTests, "3-1000");
+            var group = new CategoryGroupingTestGroup(associatedNode, "CategoryA", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+                TestFilterData.GetTestById(_loadedTests, "3-2011"),
+                TestFilterData.GetTestById(_loadedTests, "3-2012"),
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><id>3-1000</id><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixture_ReturnsCategoryFilter()
+        {
+            // Arrange
+            TestNode associatedNode = TestFilterData.GetTestById(_loadedTests, "3-1010");
+            var group = new CategoryGroupingTestGroup(associatedNode, "CategoryA", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><id>3-1010</id><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForExplicitTestFixture_ReturnsCategoryFilter()
+        {
+            // Arrange
+            TestNode associatedNode = TestFilterData.GetTestById(_loadedTests, "3-3010");
+            var group = new CategoryGroupingTestGroup(associatedNode, "CategoryA", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><id>3-3010</id><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixtureWithExplicitTestCase_ReturnsCategoryFilter()
+        {
+            // Arrange
+            TestNode associatedNode = TestFilterData.GetTestById(_loadedTests, "3-4010");
+            var group = new CategoryGroupingTestGroup(associatedNode, "CategoryA", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><id>3-4010</id><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestRun_WithNoneCategory_ReturnsVisibleIdFilterWithoutExplicit()
+        {
+            // Arrange
+            var group = new CategoryGroupingTestGroup(_loadedTests, "None", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+                TestFilterData.GetTestById(_loadedTests, "3-2011"),
+                TestFilterData.GetTestById(_loadedTests, "3-2012"),
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id><id>3-2011</id><id>3-2012</id><id>3-4011</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixture_WithNoneCategory_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            TestNode associatedNode = TestFilterData.GetTestById(_loadedTests, "3-1010");
+            var group = new CategoryGroupingTestGroup(associatedNode, "None", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForExplicitTestFixture_WithNoneCategory_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            TestNode associatedNode = TestFilterData.GetTestById(_loadedTests, "3-3010");
+            var group = new CategoryGroupingTestGroup(associatedNode, "None", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-3011</id><id>3-3012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixtureWithExplicitTestCase_WithNoneCategory_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            TestNode associatedNode = TestFilterData.GetTestById(_loadedTests, "3-4010");
+            var group = new CategoryGroupingTestGroup(associatedNode, "None", "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-4011</id>"));
+        }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/GroupingTestGroupTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/GroupingTestGroupTests.cs
@@ -1,0 +1,129 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters.Filter
+{
+    using NSubstitute;
+    using NUnit.Framework;
+    using TestCentric.Gui.Model;
+    using TestCentric.Gui.Model.Filter;
+    using TestCentric.Gui.Presenters.NUnitGrouping;
+
+    [TestFixture]
+    internal class GroupingTestGroupTests
+    {
+        private ITestCentricTestFilter _guiFilter;
+        private TestNode _loadedTests;
+
+        [SetUp]
+        public void Setup()
+        {
+            _guiFilter = Substitute.For<ITestCentricTestFilter>();
+            _loadedTests = TestFilterData.GetSampleTestProject();
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestRun_ReturnsAllNodesInGroup()
+        {
+            // Arrange
+            var associatedTestNode = _loadedTests;
+            var group = new GroupingTestGroup(associatedTestNode, "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+                TestFilterData.GetTestById(_loadedTests, "3-2011"),
+                TestFilterData.GetTestById(_loadedTests, "3-2012"),
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id><id>3-2011</id><id>3-2012</id><id>3-4011</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForAssembly_ReturnsAllNodesInGroup()
+        {
+            // Arrange
+            var associatedTestNode = TestFilterData.GetTestById(_loadedTests, "3-1001");
+            var group = new GroupingTestGroup(associatedTestNode, "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+                TestFilterData.GetTestById(_loadedTests, "3-2011"),
+                TestFilterData.GetTestById(_loadedTests, "3-2012"),
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id><id>3-2011</id><id>3-2012</id><id>3-4011</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixture_ReturnsAllNodesInGroup()
+        {
+            // Arrange
+            var associatedTestNode = TestFilterData.GetTestById(_loadedTests, "3-1010");
+            var group = new GroupingTestGroup(associatedTestNode, "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-1011"),
+                TestFilterData.GetTestById(_loadedTests, "3-1012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForExplicitTestFixture_ReturnsNonExplicitTests()
+        {
+            // Arrange
+            var associatedTestNode = TestFilterData.GetTestById(_loadedTests, "3-3010");
+            var group = new GroupingTestGroup(associatedTestNode, "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-3011"),
+                TestFilterData.GetTestById(_loadedTests, "3-3012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-3011</id><id>3-3012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForFixtureWithExplicitTestCases_ReturnsNonExplicitTests()
+        {
+            // Arrange
+            var associatedTestNode = TestFilterData.GetTestById(_loadedTests, "3-4010");
+            var group = new GroupingTestGroup(associatedTestNode, "Name")
+            {
+                TestFilterData.GetTestById(_loadedTests, "3-4011"),
+                TestFilterData.GetTestById(_loadedTests, "3-4012"),
+            };
+
+            // Act
+            var filter = group.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-4011</id>"));
+        }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/TestFilterData.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/TestFilterData.cs
@@ -1,0 +1,136 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters.Filter
+{
+    using System.Collections.Generic;
+    using TestCentric.Gui.Model;
+
+    internal static class TestFilterData
+    {
+        internal static TestNode GetSampleTestProject()
+        {
+            return new TestNode(CreateTestRunXml(
+                                    CreateTestSuiteXml("3-1000", "LibraryA",
+                                        CreateTestSuiteXml("3-1001", "NamespaceA",
+                                            CreateTestFixtureXml("3-1010", "Fixture_1", new List<string>(),
+                                                CreateTestcaseXml("3-1011", "TestA", ""),
+                                                CreateTestcaseXml("3-1012", "TestB", ""))),
+                                        CreateTestSuiteXml("3-2001", "NamespaceB", 
+                                            CreateTestFixtureXml("3-2010", "Fixture_2", new List<string>(),
+                                                CreateTestcaseXml("3-2011", "TestA", ""),
+                                                CreateTestcaseXml("3-2012", "TestB", ""))),
+                                            CreateExplicitTestFixtureXml("3-3010", "ExplicitFixture", new List<string>(),
+                                                CreateTestcaseXml("3-3011", "TestA", ""),
+                                                CreateTestcaseXml("3-3012", "TestB", "")),
+                                            CreateTestFixtureXml("3-4010", "Fixture_3", new List<string>(),
+                                                CreateTestcaseXml("3-4011", "TestA", ""),
+                                                CreateExplicitTestcaseXml("3-4012", "TestB", "")))));
+        }
+
+        internal static TestNode GetTestById(TestNode node, string id)
+        {
+            if (node.Id == id)
+                return node;
+
+            foreach (TestNode child in node.Children)
+            {
+                var foundNode = GetTestById(child, id);
+                if (foundNode != null)
+                    return foundNode;
+            }
+
+            return null;
+        }
+
+        private static string CreateTestcaseXml(string testId, string testName)
+        {
+            return CreateTestcaseXml(testId, testName, new List<string>());
+        }
+
+        private static string CreateTestcaseXml(string testId, string testName, string category)
+        {
+            return CreateTestcaseXml(testId, testName, new List<string>() { category });
+        }
+
+        private static string CreateExplicitTestcaseXml(string testId, string testName, string category)
+        {
+            return CreateTestcaseXml(testId, testName, new List<string>() { category }, true);
+        }
+
+        private static string CreateTestcaseXml(string testId, string testName, IList<string> categories, bool explicitTest = false)
+        {
+            string str = $"<test-case id='{testId}' name='{testName}' ";
+            if (explicitTest)
+                str += "runstate='Explicit' ";
+            str += "> ";
+
+            str += "<properties> ";
+            foreach (string category in categories)
+                str += $"<property name='Category' value='{category}' /> ";
+            str += "</properties> ";
+
+            str += "</test-case> ";
+
+            return str;
+        }
+
+        private static string CreateTestFixtureXml(string testId, string testName, IEnumerable<string> categories, params string[] testCases)
+        {
+            string str = $"<test-suite type='TestFixture' id='{testId}'  name='{testName}'> ";
+
+            str += "<properties> ";
+            foreach (string category in categories)
+                str += $"<property name='Category' value='{category}' /> ";
+            str += "</properties> ";
+
+            foreach (string testCase in testCases)
+                str += testCase;
+
+            str += "</test-suite>";
+
+            return str;
+        }
+
+        private static string CreateExplicitTestFixtureXml(string testId, string testName, IEnumerable<string> categories, params string[] testCases)
+        {
+            string str = $"<test-suite type='TestFixture' id='{testId}'  name='{testName}' runstate='Explicit'> ";
+
+            str += "<properties> ";
+            foreach (string category in categories)
+                str += $"<property name='Category' value='{category}' /> ";
+            str += "</properties> ";
+
+            foreach (string testCase in testCases)
+                str += testCase;
+
+            str += "</test-suite>";
+
+            return str;
+        }
+
+        private static string CreateTestSuiteXml(string testId, string testName, params string[] testSuites)
+        {
+            string str = $"<test-suite type='TestSuite' id='{testId}' name='{testName}'> ";
+            foreach (string testSuite in testSuites)
+                str += testSuite;
+
+            str += "</test-suite>";
+
+            return str;
+        }
+
+        private static string CreateTestRunXml(params string[] testSuites)
+        {
+            string str = $"<test-run type='TestRun'> ";
+            foreach (string testSuite in testSuites)
+                str += testSuite;
+
+            str += "</test-run>";
+
+            return str;
+        }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/TestSelectionTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/TestSelectionTests.cs
@@ -1,0 +1,372 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters.Filter
+{
+    using System.Collections.Generic;
+    using NSubstitute;
+    using NUnit.Framework;
+    using TestCentric.Gui.Model;
+    using TestCentric.Gui.Model.Filter;
+
+    [TestFixture]
+    internal class TestSelectionTests
+    {
+        private ITestCentricTestFilter _guiFilter;
+        private TestNode _loadedTests;
+
+        [SetUp]
+        public void Setup()
+        {
+            _guiFilter = Substitute.For<ITestCentricTestFilter>();
+            _loadedTests = TestFilterData.GetSampleTestProject();
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestRun_ReturnsEmptyFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { _loadedTests };
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.IsEmpty, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixture_ReturnsIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-1010") };
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-1010</id>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForExplicitTestFixture_ReturnsIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-3010") };
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-3010</id>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixtureWithExplicitTestcase_ReturnsIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-4010") };
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-4010</id>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestRun_WithCategoryFilter_ReturnsIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { _loadedTests };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.AllCategories.Returns(new List<string>() { "CategoryA", "CategoryB" });
+            _guiFilter.CategoryFilter.Returns(new List<string>() { "CategoryA" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><not><or><id>3-3010</id><id>3-4012</id></or></not><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixture_WithCategoryFilter_ReturnsIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-2010") };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.AllCategories.Returns(new List<string>() { "CategoryA", "CategoryB" });
+            _guiFilter.CategoryFilter.Returns(new List<string>() { "CategoryA" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><id>3-2010</id><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForExplicitTestFixture_WithCategoryFilter_ReturnsIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-3010") };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.AllCategories.Returns(new List<string>() { "CategoryA", "CategoryB" });
+            _guiFilter.CategoryFilter.Returns(new List<string>() { "CategoryA" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><id>3-3010</id><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixtureWithExplicitTestcase_WithCategoryFilter_ReturnsIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-4010") };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.AllCategories.Returns(new List<string>() { "CategoryA", "CategoryB" });
+            _guiFilter.CategoryFilter.Returns(new List<string>() { "CategoryA" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<and><id>3-4010</id><cat>CategoryA</cat></and>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestRun_WithOutcomeFilter_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { _loadedTests };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.OutcomeFilter.Returns(new List<string>() { "Passed" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id><id>3-2011</id><id>3-2012</id><id>3-4011</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixture_WithOutcomeFilter_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-1010") };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.OutcomeFilter.Returns(new List<string>() { "Passed" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForExplicitTestFixture_WithOutcomeFilter_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-3010") };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.OutcomeFilter.Returns(new List<string>() { "Passed" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-3011</id><id>3-3012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestFixtureWithExplicitTestcases_WithOutcomeFilter_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-4010") };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.OutcomeFilter.Returns(new List<string>() { "Passed" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-4011</id>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForTestAssembly_WithNoneCategoryFilter_ReturnsVisibleIdFilter()
+        {
+            // Arrange
+            var testSelection = new TestSelection() { TestFilterData.GetTestById(_loadedTests, "3-1000") };
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.AllCategories.Returns(new List<string>() { "CategoryA", "CategoryB" });
+            _guiFilter.CategoryFilter.Returns(new List<string>() { "None" });
+
+            // Act
+            var filter = testSelection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id><id>3-2011</id><id>3-2012</id><id>3-4011</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestAssembly_ReturnsIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode = TestFilterData.GetTestById(_loadedTests, "3-1000");
+            var selection = new TestSelection() { testNode };
+            selection.AddExplicitChildTests();
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1000</id><id>3-3010</id><id>3-4012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestFixture_ReturnsIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode = TestFilterData.GetTestById(_loadedTests, "3-1010");
+            var selection = new TestSelection() { testNode };
+            selection.AddExplicitChildTests();
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-1010</id>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ForExplicitTestFixture_ReturnsIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode = TestFilterData.GetTestById(_loadedTests, "3-3010");
+            var selection = new TestSelection() { testNode };
+            selection.AddExplicitChildTests();
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<id>3-3010</id>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestFixtureWithExplicitTestcase_ReturnsIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode = TestFilterData.GetTestById(_loadedTests, "3-4010");
+            var selection = new TestSelection() { testNode };
+            selection.AddExplicitChildTests();
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-4010</id><id>3-4012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestFixtures_ReturnsIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode1 = TestFilterData.GetTestById(_loadedTests, "3-1010");
+            var testNode2 = TestFilterData.GetTestById(_loadedTests, "3-3010");
+            var testNode3 = TestFilterData.GetTestById(_loadedTests, "3-4010");
+
+            var selection = new TestSelection() { testNode1, testNode2, testNode3 };
+            selection.AddExplicitChildTests();
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1010</id><id>3-3010</id><id>3-4010</id><id>3-4012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestcases_ReturnsIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode1 = TestFilterData.GetTestById(_loadedTests, "3-1012");
+            var testNode2 = TestFilterData.GetTestById(_loadedTests, "3-3012");
+            var testNode3 = TestFilterData.GetTestById(_loadedTests, "3-4012");
+
+            var selection = new TestSelection() { testNode1, testNode2, testNode3 };
+            selection.AddExplicitChildTests();
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1012</id><id>3-3012</id><id>3-4012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestAssembly_WithOutcomeFilter_ReturnsVisibleIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode = TestFilterData.GetTestById(_loadedTests, "3-1000");
+            var selection = new TestSelection() { testNode };
+            selection.AddExplicitChildTests();
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.OutcomeFilter.Returns(new List<string>() { "Passed" });
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id><id>3-2011</id><id>3-2012</id><id>3-3011</id><id>3-3012</id><id>3-4011</id><id>3-4012</id><id>3-3011</id><id>3-3012</id><id>3-4012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestFixtures_WithOutcomeFilter_ReturnsVisibleIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode1 = TestFilterData.GetTestById(_loadedTests, "3-1010");
+            var testNode2 = TestFilterData.GetTestById(_loadedTests, "3-3010");
+            var testNode3 = TestFilterData.GetTestById(_loadedTests, "3-4010");
+
+            var selection = new TestSelection() { testNode1, testNode2, testNode3 };
+            selection.AddExplicitChildTests();
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.OutcomeFilter.Returns(new List<string>() { "Passed" });
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1011</id><id>3-1012</id><id>3-3011</id><id>3-3012</id><id>3-4011</id><id>3-4012</id><id>3-4012</id></or>"));
+        }
+
+        [Test]
+        public void GetTestFilter_ExplicitChildrenIncluded_ForTestcases_WithOutcomeFilter_ReturnsVisibleIdFilterWithExplicit()
+        {
+            // Arrange
+            var testNode1 = TestFilterData.GetTestById(_loadedTests, "3-1012");
+            var testNode2 = TestFilterData.GetTestById(_loadedTests, "3-3012");
+            var testNode3 = TestFilterData.GetTestById(_loadedTests, "3-4012");
+
+            var selection = new TestSelection() { testNode1, testNode2, testNode3 };
+            selection.AddExplicitChildTests();
+            _guiFilter.IsActive.Returns(true);
+            _guiFilter.OutcomeFilter.Returns(new List<string>() { "Passed" });
+
+            // Act
+            var filter = selection.GetTestFilter(_guiFilter);
+
+            // Assert
+            Assert.That(filter.InnerXml, Is.EqualTo("<or><id>3-1012</id><id>3-3012</id><id>3-4012</id></or>"));
+        }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestGroupTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestGroupTests.cs
@@ -10,6 +10,8 @@ using NUnit.Framework;
 namespace TestCentric.Gui.Presenters
 {
     using Model;
+    using NSubstitute;
+    using TestCentric.Gui.Model.Filter;
     using TestCentric.Gui.Views;
 
     public class TestGroupTests
@@ -40,7 +42,8 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void TestTestFilter()
         {
-            var filter = XmlHelper.CreateXmlNode(_group.GetTestFilter().XmlText);
+            ITestCentricTestFilter guiFilter = Substitute.For<ITestCentricTestFilter>();
+            var filter = XmlHelper.CreateXmlNode(_group.GetTestFilter(guiFilter).XmlText);
             Assert.That(filter.Name, Is.EqualTo("filter"));
             Assert.That(filter.ChildNodes.Count, Is.EqualTo(1));
 

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGroupingTestGroup.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/CategoryGroupingTestGroup.cs
@@ -6,6 +6,7 @@
 namespace TestCentric.Gui.Presenters.NUnitGrouping
 {
     using TestCentric.Gui.Model;
+    using TestCentric.Gui.Model.Filter;
 
     /// <summary>
     /// A specialist TestGroup class which provides the Category for the TestFilter
@@ -20,5 +21,16 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
         }
 
         public string Category { get; set; }
+
+        public override TestFilter GetTestFilter(ITestCentricTestFilter guiFilter)
+        {
+            TestFilterBuilder builder = new TestFilterBuilder(guiFilter);
+            builder.AddCategory(Category);
+            builder.AddSelectedTest(AssociatedTestNode);
+
+            // Special case in which no filter can be composed and a fallback to individual IDs must be applied
+            builder.AllTestCaseProvider = GetNonExplicitTests;
+            return builder.Build();
+        }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/GroupingTestGroup.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitGrouping/GroupingTestGroup.cs
@@ -5,7 +5,9 @@
 
 namespace TestCentric.Gui.Presenters.NUnitGrouping
 {
+    using System.Collections.Generic;
     using TestCentric.Gui.Model;
+    using TestCentric.Gui.Model.Filter;
 
     /// <summary>
     /// A specialist TestGroup class which provides the associated TestNode within the NUnit tree
@@ -25,5 +27,29 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
         }
 
         public TestNode AssociatedTestNode { get; set; }
+
+        public override TestFilter GetTestFilter(ITestCentricTestFilter guiFilter)
+        {
+            TestFilterBuilder builder = new TestFilterBuilder(guiFilter);
+
+            foreach (TestNode test in GetNonExplicitTests())
+                builder.AddSelectedTest(test);
+
+            // Special case in which no filter can be composed and a fallback to individual IDs must be applied
+            builder.AllTestCaseProvider = GetNonExplicitTests;
+            return builder.Build();
+        }
+
+        protected IList<TestNode> GetNonExplicitTests()
+        {
+            IList<TestNode> result = new List<TestNode>();
+
+            foreach (TestNode test in this)
+                if (test.RunState != RunState.Explicit &&
+                    (test.Parent.RunState != RunState.Explicit || test.Parent == AssociatedTestNode))
+                    result.Add(test);
+
+            return result;
+        }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestGroup.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestGroup.cs
@@ -10,6 +10,7 @@ namespace TestCentric.Gui.Presenters
 {
     using System;
     using Model;
+    using TestCentric.Gui.Model.Filter;
 
     /// <summary>
     /// A TestGroup is essentially a TestSelection with a
@@ -44,17 +45,15 @@ namespace TestCentric.Gui.Presenters
 
         #endregion
 
-        public override TestFilter GetTestFilter()
+        public override TestFilter GetTestFilter(ITestCentricTestFilter guiFilter)
         {
-            StringBuilder sb = new StringBuilder("<filter><or>");
+            TestFilterBuilder builder = new TestFilterBuilder(guiFilter);
 
             foreach (TestNode test in this)
                 if (test.RunState != RunState.Explicit)
-                    sb.AppendFormat("<id>{0}</id>", test.Id);
+                    builder.AddSelectedTest(test);
 
-            sb.Append("</or></filter>");
-
-            return new TestFilter(sb.ToString());
+            return builder.Build();
         }
 
         /// <summary>

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
@@ -269,6 +269,7 @@ namespace TestCentric.Gui.Presenters
                 foreach (var node in checkedNodes)
                     selection.Add(node.Tag as ITestItem);
                 
+                selection.AddExplicitChildTests();
                 _model.SelectedTests = selection;
             };
 

--- a/src/GuiRunner/TestModel.Tests/TestFilterTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestFilterTests.cs
@@ -12,228 +12,214 @@ namespace TestCentric.Gui.Model
     internal class TestFilterTests
     {
         [Test]
-        public void MakeVisibleIdFilter_NoSelectedNodes_ReturnsFilter()
+        public void MakeIdFilter_TestRunNode_ReturnsEmptyFilter()
         {
             // Arrange
-            var testNodes = new List<TestNode>();
+            var testNode = new TestNode("<test-run type='TestRun' />");
 
             // Act
-            TestFilter filter = TestFilter.MakeVisibleIdFilter(testNodes);
+            TestFilter filter = TestFilter.MakeIdFilter(testNode);
 
             // Assert
-            Assert.That(filter.XmlText, Is.EqualTo("<filter><or></or></filter>"));
+            Assert.That(filter.IsEmpty, Is.True);
         }
 
         [Test]
-        public void MakeVisibleIdFilter_AllTestNodesVisible_ReturnsFilter()
+        public void MakeIdFilter_Testcase_ReturnsIdFilter()
         {
             // Arrange
-            var testNodes = new List<TestNode>()
-            {
-                new TestNode("<test-case id='1' />"),
-                new TestNode("<test-case id='2' />"),
-            };
+            var testNode = new TestNode("<test-case id='1' />");
 
             // Act
-            TestFilter filter = TestFilter.MakeVisibleIdFilter(testNodes);
+            TestFilter filter = TestFilter.MakeIdFilter(testNode);
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><id>1</id></filter>"));
+        }
+
+        [Test]
+        public void MakeIdFilter_TestFixture_ReturnsIdFilter()
+        {
+            // Arrange
+            var testNode = new TestNode("<test-suite type='TestFixture' id='100' />");
+
+            // Act
+            TestFilter filter = TestFilter.MakeIdFilter(testNode);
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><id>100</id></filter>"));
+        }
+
+        [Test]
+        public void MakeIdFilter_TestSelection_SingleTestRunNode_ReturnsEmptyFilter()
+        {
+            // Arrange
+            var testNode = new TestNode("<test-run type='TestRun' />");
+            var testSelection = new TestSelection(new[] { testNode });
+
+            // Act
+            TestFilter filter = TestFilter.MakeIdFilter(testSelection);
+
+            // Assert
+            Assert.That(filter.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void MakeIdFilter_TestSelection_SingleTestcase_ReturnsIdFilter()
+        {
+            // Arrange
+            var testNode = new TestNode("<test-case id='1' />");
+            var testSelection = new TestSelection(new[] { testNode });
+
+            // Act
+            TestFilter filter = TestFilter.MakeIdFilter(testSelection);
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><id>1</id></filter>"));
+        }
+
+        [Test]
+        public void MakeIdFilter_TestSelection_MultipleTests_ReturnsIdFilter()
+        {
+            // Arrange
+            var testNode1 = new TestNode("<test-case id='1' />");
+            var testNode2 = new TestNode("<test-suite type='TestFixture' id='100' />");
+
+            var testSelection = new TestSelection(new[] { testNode1, testNode2 });
+
+            // Act
+            TestFilter filter = TestFilter.MakeIdFilter(testSelection);
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><or><id>1</id><id>100</id></or></filter>"));
+        }
+
+        [Test]
+        public void MakeCategoryFilter_SingleCategory_ReturnsCategoryFilter()
+        {
+            // Arrange
+            // Act
+            TestFilter filter = TestFilter.MakeCategoryFilter(new[] { "CategoryA" });
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><cat>CategoryA</cat></filter>"));
+        }
+
+        [Test]
+        public void MakeCategoryFilter_MultipleCategory_ReturnsCategoryFilter()
+        {
+            // Arrange
+            // Act
+            TestFilter filter = TestFilter.MakeCategoryFilter(new[] { "CategoryA", "CategoryB" });
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><or><cat>CategoryA</cat><cat>CategoryB</cat></or></filter>"));
+        }
+
+        [Test]
+        public void MakeAndFilter_OfOneEmptyFilter_ReturnsEmptyFilter()
+        {
+            // Arrange
+            // Act
+            TestFilter filter = TestFilter.MakeAndFilter(TestFilter.Empty);
+
+            // Assert
+            Assert.That(filter.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void MakeAndFilter_OfTwoEmptyFilters_ReturnsEmptyFilter()
+        {
+            // Arrange
+            // Act
+            TestFilter filter = TestFilter.MakeAndFilter(TestFilter.Empty, TestFilter.Empty);
+
+            // Assert
+            Assert.That(filter.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void MakeAndFilter_OfFilters_ReturnsAndFilter()
+        {
+            // Arrange
+            var testNode = new TestNode("<test-case id='1' />");
+            var filter1 = TestFilter.MakeIdFilter(testNode);
+
+            // Act
+            TestFilter filter = TestFilter.MakeAndFilter(TestFilter.Empty, filter1);
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><id>1</id></filter>"));
+        }
+
+        [Test]
+        public void MakeAndFilter_OfFilters2_ReturnsAndFilter()
+        {
+            // Arrange
+            var testNode1 = new TestNode("<test-case id='1' />");
+            var filter1 = TestFilter.MakeIdFilter(testNode1);
+
+            var testNode2 = new TestNode("<test-case id='2' />");
+            var filter2 = TestFilter.MakeIdFilter(testNode2);
+
+            // Act
+            TestFilter filter = TestFilter.MakeAndFilter(filter1, filter2);
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><and><id>1</id><id>2</id></and></filter>"));
+        }
+
+        [Test]
+        public void MakeOrFilter_OfOneEmptyFilter_ReturnsEmptyFilter()
+        {
+            // Arrange
+            // Act
+            TestFilter filter = TestFilter.MakeOrFilter(TestFilter.Empty);
+
+            // Assert
+            Assert.That(filter.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void MakeOrFilter_OfTwoEmptyFilters_ReturnsEmptyFilter()
+        {
+            // Arrange
+            // Act
+            TestFilter filter = TestFilter.MakeOrFilter(TestFilter.Empty, TestFilter.Empty);
+
+            // Assert
+            Assert.That(filter.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void MakeOrFilter_OfFilters_ReturnsOrFilter()
+        {
+            // Arrange
+            var testNode = new TestNode("<test-case id='1' />");
+            var filter1 = TestFilter.MakeIdFilter(testNode);
+
+            // Act
+            TestFilter filter = TestFilter.MakeOrFilter(TestFilter.Empty, filter1);
+
+            // Assert
+            Assert.That(filter.XmlText, Is.EqualTo("<filter><id>1</id></filter>"));
+        }
+
+        [Test]
+        public void MakeOrFilter_OfFilters2_ReturnsAndFilter()
+        {
+            // Arrange
+            var testNode1 = new TestNode("<test-case id='1' />");
+            var filter1 = TestFilter.MakeIdFilter(testNode1);
+
+            var testNode2 = new TestNode("<test-case id='2' />");
+            var filter2 = TestFilter.MakeIdFilter(testNode2);
+
+            // Act
+            TestFilter filter = TestFilter.MakeOrFilter(filter1, filter2);
 
             // Assert
             Assert.That(filter.XmlText, Is.EqualTo("<filter><or><id>1</id><id>2</id></or></filter>"));
-        }
-
-        [Test]
-        public void MakeVisibleIdFilter_TestNodesNotVisible_ReturnsFilter()
-        {
-            // Arrange
-            var testNodes = new List<TestNode>()
-            {
-                new TestNode("<test-case id='1' />") { IsVisible = false },
-                new TestNode("<test-case id='2' />") { IsVisible = true },
-            };
-
-            // Act
-            TestFilter filter = TestFilter.MakeVisibleIdFilter(testNodes);
-
-            // Assert
-            Assert.That(filter.XmlText, Is.EqualTo("<filter><or><id>2</id></or></filter>"));
-        }
-
-        private static object[] MakeVisibleIdFilter =
-{
-            new object[] { new[] { "3-1000", "3-1100", "3-1110", "3-1111" }, new[] { "3-1111" }, new[] { "3-1000", "3-1100", "3-1110", "3-1112" } },
-            new object[] { new[] { "3-1000", "3-1200", "3-1210", "3-1211", "3-1212" }, new[] { "3-1211", "3-1212" }, new[] { "3-1000", "3-1100", "3-1111", "3-1112", "3-1210" } },
-            new object[] { new[] { "3-1000", "3-1300", "3-1310", "3-1312", "3-1320", "3-1322" }, new[] { "3-1312", "3-1322" }, new[] { "3-1000", "3-1300", "3-1310", "3-1311", "3-1321" } },
-            new object[] { new[] { "3-1000", "3-1300", "3-1320", "3-1322" }, new[] { "3-1322" }, new[] { "3-1000", "3-1300", "3-1310", "3-1311", "3-1312", "3-1321" } },
-        };
-
-        [Test]
-        [TestCaseSource(nameof(MakeVisibleIdFilter))]
-        public void MakeVisibleIdFilter_TestNodesHierarchie_ReturnsFilter(IList<string> visibleNodeIds, IList<string> expectedIds, IList<string> expectedIdsNotInFilter)
-        {
-            // Arrange
-            TestNode testNode = new TestNode(
-                CreateTestSuiteXml("3-1000", 
-                    CreateTestSuiteXml("3-1100", 
-                        CreateTestFixtureXml("3-1110", 
-                            CreateTestcaseXml("3-1111"),
-                            CreateTestcaseXml("3-1112"))) +
-                    CreateTestSuiteXml("3-1200", 
-                        CreateTestFixtureXml("3-1210", 
-                            CreateTestcaseXml("3-1211"),
-                            CreateTestcaseXml("3-1212"))),
-                    CreateTestSuiteXml("3-1300", 
-                        CreateTestFixtureXml("3-1310", 
-                            CreateTestcaseXml("3-1311"),
-                            CreateTestcaseXml("3-1312")) +
-                        CreateTestFixtureXml("3-1320",
-                            CreateTestcaseXml("3-1321"),
-                            CreateTestcaseXml("3-1322")))));
-
-            SetVisibleNodes(testNode, visibleNodeIds);
-
-            // Act
-            TestFilter filter = TestFilter.MakeVisibleIdFilter(new[] { testNode });
-
-            // Assert
-            string xmlText = filter.XmlText;
-
-            foreach (string id in expectedIds)
-                Assert.That(xmlText, Does.Contain($"<id>{id}</id>"));
-
-            foreach (string id in expectedIdsNotInFilter)
-                Assert.That(xmlText, Does.Not.Contain($"{id}"));
-        }
-
-        private static object[] MakeVisibleIdFilter2 =
-{
-            new object[] { new[] { "3-1000", "3-1100", "3-1110", "3-1111", "3-1112" }, new[] { "3-1112" }, new[] { "3-1000", "3-1100", "3-1110" } },
-            new object[] { new[] { "3-1000", "3-1200", "3-1210", "3-1211", "3-1212" }, new List<string>(), new[] { "3-1000", "3-1100", "3-1111", "3-1112", "3-1210", "3-1211", "3-1212" } },
-        };
-
-        [Test]
-        [TestCaseSource(nameof(MakeVisibleIdFilter2))]
-        public void MakeVisibleIdFilter_WithExplicitTests_ReturnsFilter(IList<string> visibleNodeIds, IList<string> expectedIds, IList<string> expectedIdsNotInFilter)
-        {
-            // Arrange
-            TestNode testNode = new TestNode(
-                CreateTestSuiteXml("3-1000",
-                    CreateTestSuiteXml("3-1100",
-                        CreateTestFixtureXml("3-1110",
-                            CreateTestcaseXmlWithRunState("3-1111", "Explicit"),
-                            CreateTestcaseXml("3-1112"))) +
-                    CreateTestSuiteXml("3-1200",
-                        CreateTestFixtureXml("3-1210",
-                            CreateTestcaseXmlWithRunState("3-1211", "Explicit"),
-                            CreateTestcaseXmlWithRunState("3-1212", "Explicit")))));
-
-            SetVisibleNodes(testNode, visibleNodeIds);
-
-            // Act
-            TestFilter filter = TestFilter.MakeVisibleIdFilter(new[] { testNode });
-
-            // Assert
-            string xmlText = filter.XmlText;
-
-            foreach (string id in expectedIds)
-                Assert.That(xmlText, Does.Contain($"<id>{id}</id>"));
-
-            foreach (string id in expectedIdsNotInFilter)
-                Assert.That(xmlText, Does.Not.Contain($"{id}"));
-        }
-
-        [Test]
-        public void MakeVisibleIdFilter_TestFixture_WithExplicitTests_ReturnsFilter()
-        {
-            // Arrange
-            TestNode testNode1 = new TestNode(
-                        CreateTestFixtureXml("3-1000",
-                            CreateTestcaseXmlWithRunState("3-1001", "Explicit"),
-                            CreateTestcaseXml("3-1002")));
-
-            TestNode testNode2 = new TestNode(
-                        CreateTestFixtureXml("3-2000",
-                            CreateTestcaseXmlWithRunState("3-2001", "Explicit"),
-                            CreateTestcaseXml("3-2002")));
-
-            SetVisibleNodes(testNode1, new[] { "3-1000", "3-1001", "3-1002", "3-2000", "3-2001", "3-2002" });
-
-            // Act
-            TestFilter filter = TestFilter.MakeVisibleIdFilter(new[] { testNode1, testNode2 });
-
-            // Assert
-            string xmlText = filter.XmlText;
-
-            var expectedIds = new[] { "3-1002", "3-2002" };
-            foreach (string id in expectedIds)
-                Assert.That(xmlText, Does.Contain($"<id>{id}</id>"));
-
-            var expectedIdsNotInFilter = new[] { "3-1001", "3-2001"};
-            foreach (string id in expectedIdsNotInFilter)
-                Assert.That(xmlText, Does.Not.Contain($"{id}"));
-        }
-
-        [Test]
-        public void MakeVisibleIdFilter_TestCases_WithExplicitTests_ReturnsFilter()
-        {
-            // Arrange
-            TestNode testNode1 = new TestNode(CreateTestcaseXmlWithRunState("3-1000", "Explicit"));
-            TestNode testNode2 = new TestNode(CreateTestcaseXmlWithRunState("3-1001", "Explicit"));
-            TestNode testNode3 = new TestNode(CreateTestcaseXmlWithRunState("3-1002", "Runnable"));
-
-            SetVisibleNodes(testNode1, new[] { "3-1000", "3-1001", "3-1002" });
-
-            // Act
-            TestFilter filter = TestFilter.MakeVisibleIdFilter(new[] { testNode1, testNode2, testNode3 });
-
-            // Assert
-            string xmlText = filter.XmlText;
-
-            var expectedIds = new[] { "3-1000", "3-1001", "3-1002" };
-            foreach (string id in expectedIds)
-                Assert.That(xmlText, Does.Contain($"<id>{id}</id>"));
-        }
-
-        private void SetVisibleNodes(TestNode testNode, IList<string> visibleNodeIds)
-        {
-            testNode.IsVisible = visibleNodeIds.Contains(testNode.Id);
-
-            foreach(TestNode childNode in testNode.Children)
-                SetVisibleNodes(childNode, visibleNodeIds);
-        }
-
-        private string CreateTestcaseXml(string testId)
-        {
-            string str = $"<test-case id='{testId}' /> ";
-            return str;
-        }
-
-        private string CreateTestcaseXmlWithRunState(string testId, string runstate)
-        {
-            string str = $"<test-case id='{testId}' runstate='{runstate}' /> ";
-            return str;
-        }
-
-        private string CreateTestFixtureXml(string testId, params string[] testCases)
-        {
-            string str = $"<test-suite type='TestFixture' id='{testId}' > ";
-
-            foreach (string testCase in testCases)
-                str += testCase;
-
-            str += "</test-suite>";
-
-            return str;
-        }
-
-        private string CreateTestSuiteXml(string testId, params string[] testSuites)
-        {
-            string str = $"<test-suite type='TestSuite' id='{testId}' > ";
-            foreach (string testSuite in testSuites)
-                str += testSuite;
-
-            str += "</test-suite>";
-
-            return str;
         }
     }
 }

--- a/src/GuiRunner/TestModel/Filter/TestCentricTestFilter.cs
+++ b/src/GuiRunner/TestModel/Filter/TestCentricTestFilter.cs
@@ -55,7 +55,12 @@ namespace TestCentric.Gui.Model.Filter
             }
         }
 
-        public bool IsActive => _filters.Any(x => x.IsActive);
+        public bool IsActive => IsNUnitTree && _filters.Any(x => x.IsActive);
+
+        /// <summary>
+        /// Filtering is not supported yet for category list or test list tree view 
+        /// </summary>
+        private bool IsNUnitTree => TestModel.Settings == null || TestModel.Settings.Gui.TestTree.DisplayFormat == "NUNIT_TREE";
 
         public void ResetAll(bool suppressFilterChangedEvent = false)
         {

--- a/src/GuiRunner/TestModel/Filter/TestFilterBuilder.cs
+++ b/src/GuiRunner/TestModel/Filter/TestFilterBuilder.cs
@@ -1,0 +1,155 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TestCentric.Gui.Model.Filter
+{
+    /// <summary>
+    /// This class is responsible to build up a TestFilter object using the different inputs:
+    /// - the selected tree node(s)
+    /// - the GUI tree filter (outcome, category or name)
+    /// - the tree grouping
+    /// </summary>
+    public class TestFilterBuilder
+    {
+        public TestFilterBuilder(ITestCentricTestFilter guiFilter)
+        {
+            OutcomeFilter = new List<string>();
+            CategoryFilter = new List<string>();
+            TestFilter = string.Empty;
+
+            SelectedTests = new TestSelection();
+
+            ApplyGuiFilter(guiFilter);
+        }
+
+        private IList<string> OutcomeFilter { get; }
+
+        private IList<string> CategoryFilter { get; }
+
+        private string TestFilter { get; set; }
+
+        private TestSelection SelectedTests { get; }
+
+        public Func<IEnumerable<TestNode>> AllTestCaseProvider { get; set; }
+
+        private bool EmptyCategorySelected { get; set; }
+
+
+        public TestFilter Build()
+        {
+            // There's no matching NUnit filter for outcome and tests without category.
+            // Therefore we cannot build up an enhanced filter =>
+            // Create ID filter for all visible child nodes of the SelectedTests
+            if (OutcomeFilter.Any() || EmptyCategorySelected)
+            {
+                IList<TestNode> childNodes = GetAllTestcaseNodes();
+                return Model.TestFilter.MakeIdFilter(childNodes);
+            }
+
+            // Create category filter
+            TestFilter categoryFilter = Model.TestFilter.Empty;
+            if (CategoryFilter.Any())
+                categoryFilter = Model.TestFilter.MakeCategoryFilter(CategoryFilter);
+
+            // Create test filter
+            TestFilter testFilter = Model.TestFilter.Empty;
+            if (!string.IsNullOrEmpty(TestFilter))
+                testFilter = Model.TestFilter.MakeTestFilter(TestFilter);
+
+            // Create ID filter for selected tests
+            TestFilter idFilter = Model.TestFilter.MakeIdFilter(SelectedTests);
+            if (idFilter.IsEmpty && (CategoryFilter.Any() || !string.IsNullOrEmpty(TestFilter)))
+            {
+                // Exceptional case: category/test filter will match also all explicit child tests => add explicit tests as NOT filter
+                TestFilter explicitFilter = Model.TestFilter.MakeIdFilter(SelectedTests.GetExplicitChildNodes());
+                idFilter = Model.TestFilter.MakeNotFilter(explicitFilter);
+            }
+
+            // Combine all filters into a single one
+            return Model.TestFilter.MakeAndFilter(idFilter, categoryFilter, testFilter);
+        }
+
+        private void ApplyGuiFilter(ITestCentricTestFilter guiFilter)
+        {
+            if (!guiFilter.IsActive)
+                return;
+
+            if (guiFilter.AllCategories.Except(guiFilter.CategoryFilter).Any())
+                foreach (string category in guiFilter.CategoryFilter)
+                    AddCategory(category);
+
+            foreach (string outcome in guiFilter.OutcomeFilter)
+                AddOutcome(outcome);
+
+            if (!string.IsNullOrEmpty(guiFilter.TextFilter))
+                AddTestFilter(guiFilter.TextFilter);
+        }
+
+
+        public void AddSelectedTest(TestNode test)
+        {
+            SelectedTests.Add(test);
+        }
+
+
+        public void AddCategory(string category)
+        {
+            if (category == "None" || category == Filter.CategoryFilter.NoCategory)
+                EmptyCategorySelected = true;
+            else
+                CategoryFilter.Add(category);
+        }
+
+        private void AddOutcome(string outcome)
+        {
+            OutcomeFilter.Add(outcome);
+        }
+
+        private void AddTestFilter(string testFilter)
+        {
+            TestFilter = testFilter;
+        }
+
+        /// <summary>
+        /// This list of test cases is only required in case an outcome filter is active in the UI
+        /// Get list of all test case IDs
+        /// </summary>
+        private IList<TestNode> GetAllTestcaseNodes()
+        {
+            IList<TestNode> result = new List<TestNode>();
+
+            // Use registered callback (if) to get all test cases
+            if (AllTestCaseProvider != null)
+                return AllTestCaseProvider().ToList();
+
+            var selection = SelectedTests.ToList();
+            foreach (TestNode testNode in selection)
+                GetAllTestcaseNodes(testNode, result);
+
+            return result;
+        }
+
+        private void GetAllTestcaseNodes(TestNode testNode, IList<TestNode> result)
+        {
+            // Only consider Visible nodes (e.g. nodes not filtered out by the UI filter)
+            if (!testNode.IsVisible)
+                return;
+
+            // Ignore explicit tests except those which were selected by the user actively 
+            if (!SelectedTests.Contains(testNode) && testNode.RunState == RunState.Explicit)
+                return;
+
+            if (!testNode.IsProject && !testNode.IsSuite && testNode.Children.Count == 0)
+                result.Add(testNode);
+
+            foreach (TestNode testNodeChild in testNode.Children)
+                GetAllTestcaseNodes(testNodeChild, result);
+        }
+    }
+}

--- a/src/GuiRunner/TestModel/ITestItem.cs
+++ b/src/GuiRunner/TestModel/ITestItem.cs
@@ -16,12 +16,5 @@ namespace TestCentric.Gui.Model
         /// The name of this item
         /// </summary>
         string Name { get; }
-
-        /// <summary>
-        /// Get a TestFilter for use in selecting this item
-        /// to be run by the engine.
-        /// </summary>
-        /// <returns></returns>
-        TestFilter GetTestFilter();
     }
 }

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -823,15 +823,9 @@ namespace TestCentric.Gui.Model
             if (_lastTestRun == null)
                 throw new InvalidOperationException("Field '_lastTestRun' is null");
 
-            // Create a test filter incorporating both the
-            // selected tests and the category filter.
-            var filter = runSpec.SelectedTests.GetTestFilter();
-            if (!runSpec.CategoryFilter.IsEmpty)
-                filter = TestFilter.MakeAndFilter(filter, runSpec.CategoryFilter);
-
-            // If a filter is active in the UI, a TestFilter must be created accordingly that contains the ID all visible children of the selected nodes.
-            if (Settings.Gui.TestTree.DisplayFormat == "NUNIT_TREE" && TestCentricTestFilter.IsActive)
-                filter = TestFilter.MakeVisibleIdFilter(runSpec.SelectedTests);
+            // Create a test filter incorporating the selected tests, the tree grouping
+            // and the UI tree filter (category, outcome or duration)
+            TestFilter filter = runSpec.SelectedTests.GetTestFilter(TestCentricTestFilter);
 
             // We need to re-create the test runner because settings such
             // as debugging have already been passed to the test runner.

--- a/src/GuiRunner/TestModel/TestNode.cs
+++ b/src/GuiRunner/TestModel/TestNode.cs
@@ -55,15 +55,6 @@ namespace TestCentric.Gui.Model
 
         public string Name => Xml.GetAttribute("name");
 
-        public TestFilter GetTestFilter()
-        {
-            return Xml.Name == "test-run"
-                ? TestFilter.Empty
-                : IsSuite && Type == "Project"
-                    ? TestFilter.MakeIdFilter(Children)
-                    : TestFilter.MakeIdFilter(this);
-        }
-
         #endregion
 
         #region Additonal Public Properties


### PR DESCRIPTION
This PR fixes #222 by using an enhanced NUnit filter in these use cases:

- category filtering in the UI
- test name filtering in the UI
- category grouping

Previously, an ID filter was used in these use cases, which could sometimes become very lengthy.
Special care was required to handle explicit tests properly. For example a NUnit category filter will include all explicit tests using that category. However in the UI we want to remain the behavior that a user has to actively select an explicit test for execution. 

There are still use cases open in which an enhanced NUnit filter could be applied. For that the implementation can be extended. For example if all tests without a category are executed ('No category grouping'). I managed to find a matching NUnit filter:
``
new TestFilter("<filter><not><cat re=\"1\">.+</cat></not></filter>");
``
But there were side effects to explicit tests, that's why I've stopped for now on this optimization.

Another optimization might work in case an outcome filter is applied in the UI. Currently the IDs of all test cases are collected for the ID filter in this case. However if all test cases of a fixture are included, the set of test case IDs could be replaced by the fixture ID instead. (Same with namespace and fixture....) This would further reduce the ID filter.

For the test name filtering I use a regex test filter - that works fine!
``
new TestFilter($"<filter><test re=\"1\">(.)*{text}(.)*</test></filter>");
``

I introduced a `TestFilterBuild` class which receive all inputs (TestSelection, grouping and UI filter) and builds up the filter accordingly. That helps to implement some rules centrally and only once.
