### PR TITLE
Fix serialization of package settings

### DIFF
--- a/src/TestEngine/TestCentric.Engine.Api.Tests/PackageSettingsTests.cs
+++ b/src/TestEngine/TestCentric.Engine.Api.Tests/PackageSettingsTests.cs
@@ -1,0 +1,51 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using NUnit.Framework;
+
+namespace TestCentric.Engine
+{
+    [TestFixture]
+    internal class PackageSettingsTests
+    {
+        [TestCase(nameof(SettingDefinitions.ShadowCopyFiles), "True", true)]
+        [TestCase(nameof(SettingDefinitions.ShadowCopyFiles), "False", false)]
+        [TestCase(nameof(SettingDefinitions.ShadowCopyFiles), "false", false)]
+        [TestCase(nameof(SettingDefinitions.ShadowCopyFiles), "FALSE", false)]
+        [TestCase(nameof(SettingDefinitions.TestRunTimeout), "10", 10)]
+        [TestCase(nameof(SettingDefinitions.TestRunTimeout), "0", 0)]
+        [TestCase(nameof(SettingDefinitions.TestRunTimeout), "-100", -100)]
+        [TestCase(nameof(SettingDefinitions.SelectedAgentName), "Agent", "Agent")]
+        [TestCase(nameof(SettingDefinitions.SelectedAgentName), "", "")]
+        public void Add_Setting_AsString(string settingName, string stringValue, object expectedValue)
+        {
+            // Arrange
+            PackageSettings settings = new PackageSettings();
+
+            // Act
+            settings.Add(settingName, stringValue);
+
+            // Assert
+            var value = settings.GetSetting(settingName);
+            Assert.That(value, Is.EqualTo(expectedValue));
+        }
+
+        [TestCase("UnknownSetting", "Value", "Value")]
+        public void Add_UnknownSetting_AsString(string settingName, string stringValue, string expectedValue)
+        {
+            // Arrange
+            PackageSettings settings = new PackageSettings();
+
+            // Act
+            settings.Add(settingName, stringValue);
+
+            // Assert
+            Assert.That(settings.HasSetting(settingName), Is.True);
+
+            var value = settings.GetSetting(settingName);
+            Assert.That(value, Is.EqualTo(expectedValue));
+        }
+    }
+}

--- a/src/TestEngine/TestCentric.Engine.Api.Tests/PackageSettingsTests.cs
+++ b/src/TestEngine/TestCentric.Engine.Api.Tests/PackageSettingsTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace TestCentric.Engine
 {
     [TestFixture]
-    internal class PackageSettingsTests
+    internal class PackageSettingFactoryTests
     {
         [TestCase(nameof(SettingDefinitions.ShadowCopyFiles), "True", true)]
         [TestCase(nameof(SettingDefinitions.ShadowCopyFiles), "False", false)]
@@ -19,33 +19,25 @@ namespace TestCentric.Engine
         [TestCase(nameof(SettingDefinitions.TestRunTimeout), "-100", -100)]
         [TestCase(nameof(SettingDefinitions.SelectedAgentName), "Agent", "Agent")]
         [TestCase(nameof(SettingDefinitions.SelectedAgentName), "", "")]
-        public void Add_Setting_AsString(string settingName, string stringValue, object expectedValue)
+        public void Create_KnownSetting_StringIsConvertedIntoTargetType(string settingName, string stringValue, object expectedValue)
         {
-            // Arrange
-            PackageSettings settings = new PackageSettings();
-
             // Act
-            settings.Add(settingName, stringValue);
+            PackageSetting setting = PackageSettingFactory.Create(settingName, stringValue);
 
             // Assert
-            var value = settings.GetSetting(settingName);
-            Assert.That(value, Is.EqualTo(expectedValue));
+            Assert.That(setting.Value, Is.EqualTo(expectedValue));
         }
 
         [TestCase("UnknownSetting", "Value", "Value")]
-        public void Add_UnknownSetting_AsString(string settingName, string stringValue, string expectedValue)
+        [TestCase("UnknownSetting", "100", "100")]
+        [TestCase("UnknownSetting", "true", "true")]
+        public void Create_UnknownSetting_StringIsStored(string settingName, string stringValue, object expectedValue)
         {
-            // Arrange
-            PackageSettings settings = new PackageSettings();
-
             // Act
-            settings.Add(settingName, stringValue);
+            PackageSetting setting = PackageSettingFactory.Create(settingName, stringValue);
 
             // Assert
-            Assert.That(settings.HasSetting(settingName), Is.True);
-
-            var value = settings.GetSetting(settingName);
-            Assert.That(value, Is.EqualTo(expectedValue));
+            Assert.That(setting.Value, Is.EqualTo(expectedValue));
         }
     }
 }

--- a/src/TestEngine/TestCentric.Engine.Api.Tests/TestPackageTests.cs
+++ b/src/TestEngine/TestCentric.Engine.Api.Tests/TestPackageTests.cs
@@ -115,7 +115,12 @@ namespace TestCentric.Engine.Api
         {
             Assert.That(actual.ID, Is.EqualTo(expected.ID));
             Assert.That(actual.FullName, Is.EqualTo(expected.FullName));
-            //Assert.That(actual.Settings, Is.EquivalentTo(expected.Settings));
+            foreach (PackageSetting setting in expected.Settings)
+            {
+                Assert.That(actual.Settings.HasSetting(setting.Name), Is.True);
+                Assert.That(actual.Settings.GetSetting(setting.Name), Is.EqualTo(setting.Value));
+            }
+
             Assert.That(actual.SubPackages.Count, Is.EqualTo(expected.SubPackages.Count));
 
             for (int i = 0; i < expected.SubPackages.Count; i++)
@@ -140,6 +145,7 @@ namespace TestCentric.Engine.Api
             package = new TestPackage("test1.dll", "test2.dll", "test3.dll");
             package.AddSetting("StringSetting", "xyz");
             package.AddSetting("IntSetting", 123);
+            package.AddSetting("BoolSetting", true);
             package.SubPackages[0].AddSetting("Comment", "This is test1");
             package.SubPackages[1].AddSetting("Comment", "This is test2");
             package.SubPackages[2].AddSetting("Comment", "This is test3");

--- a/src/TestEngine/TestCentric.Engine.Api/PackageSetting.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/PackageSetting.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -74,6 +74,23 @@ namespace TestCentric.Engine
             int hash = Name.GetHashCode();
             hash ^= Value.GetHashCode();
             return hash;
+        }
+    }
+
+    /// <summary>
+    /// Factory class to create PackageSetting objects
+    /// </summary>
+    public static class PackageSettingFactory
+    {
+        /// <summary>
+        /// Creates a PackageSetting<T> object
+        /// If the name is a known SettingDefinition name, the string is converted to the TargeType of that SettingDefinition.
+        /// Otherwise a PackageSetting<string> object is created 
+        /// This method is required to deserialize PackageSettings from a string representation back to a typed PackageSetting<T>
+        public static PackageSetting Create(string name, string value)
+        {
+            SettingDefinition definition = SettingDefinitions.Lookup(name);
+            return definition != null ? definition.WithParsedValue(value) : new PackageSetting<string>(name, value);
         }
     }
 }

--- a/src/TestEngine/TestCentric.Engine.Api/PackageSettings.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/PackageSettings.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -68,13 +68,17 @@ namespace TestCentric.Engine
         public void Add(PackageSetting setting) => _settings.Add(setting.Name, setting);
 
         /// <summary>
-        /// Creates and adds a custom string setting to the list, specifying the name and value.
+        /// Creates and adds a setting to the list, specifyied by the name and a string value.
+        /// The string value is converted to a typed PackageSetting if the name specifies a known SettingDefinition.
         /// </summary>
         /// <param name="name">The name of the setting.</param>
         /// <param name="value">The corresponding value to set.</param>
         public void Add(string name, string value)
         {
-            Add(new PackageSetting<string>(name, value));
+            SettingDefinition definition = SettingDefinitions.Lookup(name);
+            PackageSetting setting = definition != null ? definition.WithParsedValue(value) : new PackageSetting<string>(name, value);
+            Add(setting);
+
         }
 
         /// <summary>

--- a/src/TestEngine/TestCentric.Engine.Api/PackageSettings.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/PackageSettings.cs
@@ -68,17 +68,14 @@ namespace TestCentric.Engine
         public void Add(PackageSetting setting) => _settings.Add(setting.Name, setting);
 
         /// <summary>
-        /// Creates and adds a setting to the list, specifyied by the name and a string value.
+        /// Creates and adds a setting to the list, specified by the name and a string value.
         /// The string value is converted to a typed PackageSetting if the name specifies a known SettingDefinition.
         /// </summary>
         /// <param name="name">The name of the setting.</param>
         /// <param name="value">The corresponding value to set.</param>
         public void Add(string name, string value)
         {
-            SettingDefinition definition = SettingDefinitions.Lookup(name);
-            PackageSetting setting = definition != null ? definition.WithParsedValue(value) : new PackageSetting<string>(name, value);
-            Add(setting);
-
+            Add(PackageSettingFactory.Create(name, value));
         }
 
         /// <summary>

--- a/src/TestEngine/TestCentric.Engine.Api/SettingDefinition.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/SettingDefinition.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -42,6 +42,24 @@ namespace TestCentric.Engine
         {
             return new PackageSetting<T>(Name, value);
         }
+
+        /// <summary>
+        /// Create a PackageSetting based on this definition.
+        /// </summary>
+        /// <param name="value">A string value which is parsed to the target type (ValueType).</param>
+        /// <returns>A PackageSetting.</returns>
+        public PackageSetting WithParsedValue(string value)
+        {
+            if (ValueType == typeof(bool) && bool.TryParse(value, out bool boolValue))
+                return new PackageSetting<bool>(Name, boolValue);
+            if (ValueType == typeof(int) && int.TryParse(value, out int intValue))
+                return new PackageSetting<int>(Name, intValue);
+            if (ValueType == typeof(string))
+                return new PackageSetting<string>(Name, value);
+
+            throw new NotSupportedException($"Unsupported type {ValueType}");
+        }
+
     }
 
     /// <summary>

--- a/src/TestEngine/TestCentric.Engine.Api/SettingDefinitions.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/SettingDefinitions.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 
 namespace TestCentric.Engine
 {
@@ -341,6 +342,23 @@ namespace TestCentric.Engine
         /// </summary>
         public static SettingDefinition<IDictionary<string, string>> TestParametersDictionary { get; } = new(nameof(TestParametersDictionary), new Dictionary<string, string>());
 
-#endregion
+        #endregion
+
+        /// <summary>
+        /// Search for one of the defined SettingsDefinition by name
+        /// Return null if no SettingDefinition is defined with this name
+        /// </summary>
+        public static SettingDefinition Lookup(string name)
+        {
+            // Get a list of all public properties
+            var properties = typeof(SettingDefinitions).GetProperties(BindingFlags.Public | BindingFlags.Static);
+
+            foreach (PropertyInfo propertyInfo in properties)
+                if (propertyInfo.Name == name)
+                    return propertyInfo.GetValue(null, null) as SettingDefinition;
+
+            return null;
+        }
+
     }
 }

--- a/src/TestEngine/TestCentric.Engine.Api/SettingDefinitions.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/SettingDefinitions.cs
@@ -18,6 +18,8 @@ namespace TestCentric.Engine
     /// </summary>
     public static class SettingDefinitions
     {
+        private static IList<PropertyInfo> _propertyInfos;
+
         #region Settings Used by the Engine
 
         /// <summary>
@@ -350,10 +352,11 @@ namespace TestCentric.Engine
         /// </summary>
         public static SettingDefinition Lookup(string name)
         {
-            // Get a list of all public properties
-            var properties = typeof(SettingDefinitions).GetProperties(BindingFlags.Public | BindingFlags.Static);
+            // Get a list of all public properties only once
+            if (_propertyInfos == null)
+                _propertyInfos = typeof(SettingDefinitions).GetProperties(BindingFlags.Public | BindingFlags.Static);
 
-            foreach (PropertyInfo propertyInfo in properties)
+            foreach (PropertyInfo propertyInfo in _propertyInfos)
                 if (propertyInfo.Name == name)
                     return propertyInfo.GetValue(null, null) as SettingDefinition;
 

--- a/src/TestEngine/TestCentric.Engine.Api/TestPackage.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/TestPackage.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -279,7 +279,15 @@ namespace TestCentric.Engine
                             {
                                 case "Settings":
                                     while (reader.MoveToNextAttribute())
-                                        package.AddSetting(reader.Name, reader.Value);
+                                    {
+                                        string value = reader.Value;
+                                        if (Boolean.TryParse(value, out bool boolValue))
+                                            package.AddSetting(reader.Name, boolValue);
+                                        else if (int.TryParse(value, out int intValue))
+                                            package.AddSetting(reader.Name, intValue);
+                                        else
+                                            package.AddSetting(reader.Name, value);
+                                    }
                                     reader.MoveToElement();
                                     break;
 

--- a/src/TestEngine/TestCentric.Engine.Api/TestPackage.cs
+++ b/src/TestEngine/TestCentric.Engine.Api/TestPackage.cs
@@ -180,7 +180,8 @@ namespace TestCentric.Engine
         }
 
         /// <summary>
-        /// Create and add a custom string setting to a package and all of its subpackages.
+        /// Create and add a custom setting to a package and all of its subpackages.
+        /// The string value is converted to a typed PackageSetting if the name specifies a known SettingDefinition.
         /// </summary>
         /// <param name="name">The name of the setting.</param>
         /// <param name="value">The corresponding value to set.</param>
@@ -193,7 +194,7 @@ namespace TestCentric.Engine
         /// </remarks>
         public void AddSetting(string name, string value)
         {
-            AddSetting(new PackageSetting<string>(name, value));
+            AddSetting(PackageSettingFactory.Create(name, value));
         }
 
         /// <summary>
@@ -279,15 +280,7 @@ namespace TestCentric.Engine
                             {
                                 case "Settings":
                                     while (reader.MoveToNextAttribute())
-                                    {
-                                        string value = reader.Value;
-                                        if (Boolean.TryParse(value, out bool boolValue))
-                                            package.AddSetting(reader.Name, boolValue);
-                                        else if (int.TryParse(value, out int intValue))
-                                            package.AddSetting(reader.Name, intValue);
-                                        else
-                                            package.AddSetting(reader.Name, value);
-                                    }
+                                        package.AddSetting(reader.Name, reader.Value);
                                     reader.MoveToElement();
                                     break;
 


### PR DESCRIPTION
This PR fixes #1315 

Although the issue is about one dedicated use case, it turns out to be a general issue of the package settings which might cause negative effects also in other use cases.

The package settings support different typed settings (string, int, bool) and a typed access `T GetValueOrDefault<T>(...)`. When serializing the package settings from the UI process to the agent process all settings are serialized as a string. So far, so good. However, when a setting is to be deserialized, it is not known which target type should be used (int, bool or string). That is why, until now, all settings were restored as strings during deserialization.
That means basically, that all int, bool settings were transformed to a string setting:
  ShadowCopyFiles=true => ShadowCopyFiles="true"
  TestRunTimeout=30 => TestRunTimeout="30"

Accessing such a setting afterwards `bool v = packageSettings.GetValueOrDefault(SettingDefinitionsShadowCopyFiles)` will always return false;

As a solution, I chose a simple approach that checks whether a bool or int is present by using the `TryParse` method. This works fine, but I'm aware that this solution is not perfect! For example if we intend to store the string "True" it will be converted to a bool, now. That's also an unexpected behavior, but I think that it's more a theoretical edge case. 

A different solution might include the type in the serialization stream. Or we might identify the target type by looking up the set of SettingDefinitions using the setting name. If you prefer one of these alternative approaches, I can try to improve the approach.



